### PR TITLE
Fix bug uploading unicode object

### DIFF
--- a/git-remote-dropbox
+++ b/git-remote-dropbox
@@ -590,7 +590,7 @@ class Helper(object):
         self._trace('writing ref %s with mode %s' % (dst, mode))
         data = '%s\n' % new_sha
         try:
-            self._connection().files_upload(data, path, mode, mute=True)
+            self._connection().files_upload(data.encode('utf-8'), path, mode, mute=True)
         except dropbox.exceptions.ApiError as e:
             if not isinstance(e.reason, dropbox.files.UploadError):
                 raise

--- a/git-remote-dropbox
+++ b/git-remote-dropbox
@@ -202,9 +202,11 @@ def git_referenced_objects(sha):
                 break
         return objs
     elif kind == 'tree':
-        # tree objects reference zero or more trees and blobs
+        # tree objects reference zero or more trees and blobs, or submodules
         lines = data.split('\n')
-        return [line.split()[2] for line in lines]
+        # submodules have the mode '160000' and the kind 'commit', we filter them out because
+        # there is nothing to download and this causes errors
+        return [line.split()[2] for line in lines if not line.startswith('160000 commit ')]
     else:
         raise Exception('unexpected git object type: %s' % kind)
 

--- a/git-remote-dropbox
+++ b/git-remote-dropbox
@@ -590,7 +590,7 @@ class Helper(object):
         self._trace('writing ref %s with mode %s' % (dst, mode))
         data = '%s\n' % new_sha
         try:
-            self._connection().files_upload(data.encode('utf-8'), path, mode, mute=True)
+            self._connection().files_upload(data, path, mode, mute=True)
         except dropbox.exceptions.ApiError as e:
             if not isinstance(e.reason, dropbox.files.UploadError):
                 raise


### PR DESCRIPTION
In circumstances that aren't clear to me... sometimes data is unicode, this causes pyopenssl
to barf when it tries to create a `memoryview`, by encoding as utf8 this won't happen, this is
benign in all other scenarios