### PR TITLE
Fix bug with initializing new repositories remotely

### DIFF
--- a/git-remote-dropbox
+++ b/git-remote-dropbox
@@ -612,7 +612,7 @@ class Helper(object):
                 res = self._connection().files_list_folder_continue(res.cursor)
                 files.extend(res.entries)
         except dropbox.exceptions.ApiError as e:
-            if not isinstance(e.error, dropbox.files.ListFolderError):
+            if hasattr(e, 'error') and not isinstance(e.error, dropbox.files.ListFolderError):
                 raise
             if not for_push:
                 # if we're pushing, it's okay if nothing exists beforehand,


### PR DESCRIPTION
For some reason the "error" field was missing from an error returned by
the Dropbox API. This was causing the initial push to fail with an
"error: unexpected exception".

This is a hack that fixed it for me. This is probably not the best way
but it's something. Could be worth looking into the source of this
problem more. Not sure why it happened now and not before.

To reproduce:
```
mkdir example; cd example
git init
echo "#Hello World" > README.md
git add *; git commit -m "initial commit"
git remote add origin "dropbox::/example"
git push --set-upstream origin master
```
results in
```
error: unexpected exception
```
with traceback
```
Traceback (most recent call last):
  File "/Users/julian/.dotfiles/bin/git-remote-dropbox", line 679, in main
    helper.run()
  File "/Users/julian/.dotfiles/bin/git-remote-dropbox", line 349, in run
    self._do_list(line)
  File "/Users/julian/.dotfiles/bin/git-remote-dropbox", line 374, in _do_list
    refs = self._get_refs(for_push=for_push)
  File "/Users/julian/.dotfiles/bin/git-remote-dropbox", line 615, in _get_refs
    if not isinstance(e.error, dropbox.files.ListFolderError):
AttributeError: 'ApiError' object has no attribute 'error'
```
No problems with repos that were already on my Dropbox.