### PR TITLE
Read configuration file from XDG location

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ Setup
    with full access to all files and file types, and generating an access token
    for yourself.
 
-3. Save your OAuth token in ``~/.git-remote-dropbox.json``. The file should
-   look something like this:
+3. Save your OAuth token in ``~/.config/git/git-remote-dropbox.json`` or
+   ``~/.git-remote-dropbox.json``. The file should look something like this:
 
 .. code:: json
 


### PR DESCRIPTION
Git itself has started using ~/.config/git/ as of 1.7.12, so getting rid of extra clutter in ~/ would be a welcome change.

Though I'm not sure if I should have used `xdg.BaseDirectory` from PyXDG instead?