### PR TITLE
Fix windows issues

### DIFF
--- a/git-remote-dropbox
+++ b/git-remote-dropbox
@@ -590,7 +590,7 @@ class Helper(object):
         self._trace('writing ref %s with mode %s' % (dst, mode))
         data = '%s\n' % new_sha
         try:
-            self._connection().files_upload(data, path, mode, mute=True)
+            self._connection().files_upload(data.encode('utf-8'), path, mode, mute=True)
         except dropbox.exceptions.ApiError as e:
             if not isinstance(e.reason, dropbox.files.UploadError):
                 raise

--- a/git-remote-dropbox
+++ b/git-remote-dropbox
@@ -202,9 +202,11 @@ def git_referenced_objects(sha):
                 break
         return objs
     elif kind == 'tree':
-        # tree objects reference zero or more trees and blobs
+        # tree objects reference zero or more trees and blobs, or submodules
         lines = data.split('\n')
-        return [line.split()[2] for line in lines]
+        # submodules have the mode '160000' and the kind 'commit', we filter them out because
+        # there is nothing to download and this causes errors
+        return [line.split()[2] for line in lines if not line.startswith('160000 commit ')]
     else:
         raise Exception('unexpected git object type: %s' % kind)
 

--- a/git-remote-dropbox
+++ b/git-remote-dropbox
@@ -590,7 +590,7 @@ class Helper(object):
         self._trace('writing ref %s with mode %s' % (dst, mode))
         data = '%s\n' % new_sha
         try:
-            self._connection().files_upload(data.encode('utf-8'), path, mode, mute=True)
+            self._connection().files_upload(data, path, mode, mute=True)
         except dropbox.exceptions.ApiError as e:
             if not isinstance(e.reason, dropbox.files.UploadError):
                 raise

--- a/git_remote_dropbox/__init__.py
+++ b/git_remote_dropbox/__init__.py
@@ -65,6 +65,15 @@ def readline():
     return sys.stdin.readline().strip()  # remove trailing newline
 
 
+def stdout_to_binary():
+    """
+    Ensure that stdout is in binary mode on windows
+    """
+    if sys.platform == 'win32':
+        import msvcrt
+        msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+
+
 def git_command_output(*args, **kwargs):
     """
     Return the result of running a git command.
@@ -340,6 +349,8 @@ class Helper(object):
         """
         Run the helper following the git remote helper communication protocol.
         """
+        stdout_to_binary()
+
         while True:
             line = readline()
             if line == 'capabilities':
@@ -719,7 +730,4 @@ def main():
 
 
 if __name__ == '__main__':
-    if sys.platform == 'win32':
-        import msvcrt
-        msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
     main()


### PR DESCRIPTION
Fix issue #13 

When git-remote-dropbox is installed using `setup.py`, the entrypoint becomes `main()` directly (i.e. the `if __name__ == '__main__':` branch doesn't get executed).

This change moves the code that converts stdout to binary into the helper run method, which means it will always be called regardless of how the module is executed.