### PR TITLE
Updated README.rst (invalid link)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Contributing
 ------------
 
 Do you have ideas on how to improve git-remote-dropbox? Have a feature request,
-bug report, or patch? Great! See `CONTRIBUTING.rst <CONTRIBUTING.rst>`__ for
+bug report, or patch? Great! See `CONTRIBUTING.md <CONTRIBUTING.md>`__ for
 information on what you can do about that.
 
 Packaging


### PR DESCRIPTION
Corrected the invalid link [CONTRIBUTING.rst](https://github.com/anishathalye/git-remote-dropbox/blob/master/CONTRIBUTING.rst) to [CONTRIBUTING.md](https://github.com/anishathalye/git-remote-dropbox/blob/master/CONTRIBUTING.md)

Just a tiny error