### PR TITLE
Fix bug when fetching already downloaded reference

### DIFF
--- a/git_remote_dropbox/__init__.py
+++ b/git_remote_dropbox/__init__.py
@@ -558,6 +558,7 @@ class Helper(object):
             proc.start()
             procs.append(proc)
         self._trace('', level=Level.INFO, exact=True) # for showing progress
+        done = total = 0
         while queue or pending:
             if queue:
                 # if possible, queue up download


### PR DESCRIPTION
If a reference is fetched and all of it's objects are already
downloaded, `done` and `total` are never set, so when writing out the
message after completed the fetching it throws an `UnboundLocalError`
exception.

At least for me on windows and python3
My test case starting with a new empty repo:
Commit to master, create new branch, commit to it and push it to dropbox.
When cloning it, fetching the one commit ahead branch will pull all the objects of master, therefore when fetching master it will report done/total = 0/0