### PR TITLE
Fix push error message description

### DIFF
--- a/git_remote_dropbox/__init__.py
+++ b/git_remote_dropbox/__init__.py
@@ -623,9 +623,11 @@ class Helper(object):
             info = self._refs.get(dst, None)
             if info:
                 rev, sha = info
+                if not git_object_exists(sha):
+                    return 'fetch first'
                 is_fast_forward = git_is_ancestor(sha, new_sha)
                 if not is_fast_forward and not force:
-                    return 'non-fast-forward'
+                    return 'non-fast forward'
                 # perform an atomic compare-and-swap
                 mode = dropbox.files.WriteMode.update(rev)
             else:


### PR DESCRIPTION
Aiming to resolve #64 

When the remote helper detects error while pushing, it should state
that in a `error <dst> <why>` manner.
The client display more descriptive error if the `why` is in some
predefined set of strings, such as `fetch first`, `non-fast forward`
(see `transport-helper.c` in the git client's source).

The remote helper incorrectly reports `non-fast-forward` instead of
`non-fast forward`.
When the remote branch's tip is not present locally it should be report
that with `fetch first`.

This commit fix thoose issues.