### PR TITLE
Add reminder that executable is on $PATH

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,8 @@ concurrent operations, even when using a shared folder.
 Setup
 -----
 
-1. Install the helper with ``pip install git-remote-dropbox``.
+1. Install the helper with ``pip install git-remote-dropbox``. Make sure the
+   ``git-remote-dropbox`` executable is on your ``$PATH``.
 
 2. Generate an OAuth 2 token by going to the `app console
    <https://www.dropbox.com/developers/apps>`__, creating a Dropbox API app


### PR DESCRIPTION
Thanks to Vincent for pointing out that this should be mentioned in the README.

Fixes #85