### PR TITLE
Migrate to using PKCE and refresh tokens

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: 3.6 # oldest supported version
       - run: |
           python -m pip install --upgrade pip
           pip install mypy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     environment: main
     strategy:
       matrix:
-        python: [2.7, pypy2, 3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
     name: "Test: Python ${{ matrix.python }}"
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +22,18 @@ jobs:
       - run: ./test/test.sh
         env:
           DROPBOX_TOKEN: ${{ secrets.DROPBOX_TOKEN }}
+  typecheck:
+    name: Type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6 # oldest supported version
+      - run: |
+          python -m pip install --upgrade pip
+          pip install mypy
+      - run: mypy git_remote_dropbox
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 =====================
 
-**Copyright (c) 2015-2021 Anish Athalye (me@anishathalye.com)**
+**Copyright (c) 2015-2022 Anish Athalye (me@anishathalye.com)**
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -36,78 +36,50 @@ concurrent operations, even when using a shared folder.
 
 ## Setup
 
-### A. Get access token from Dropbox
-
-1. Go to the Dropbox [app console](https://www.dropbox.com/developers/apps) (may require login).
-
-2. Click "Create app".
-
-3. Select "Scoped access" (you don't have a choice).
-
-4. Select "Full Dropbox".
-
-5. Name your app (e.g. "Git Remote"; you need a unique name, but it doesn't matter what name you choose).
-
-6. Click "Create app". You will now see a configuration page. Make sure you are on the "Settings" tab.
-
-7. Scroll down to the "OAuth 2" section, and change the "Access token expiration" to "No expiration".
-
-8. On the "Permissions" tab, under "Files and folders" select `files.metadata.write` (which also selects `files.metadata.read`), `files.content.write`, and `files.content.read`. Click "Submit" at the bottom. (You must make sure to do this _before_ the next step, because changing permissions does not affect existing access tokens.)
-
-9. Back on the "Settings" tab, click "Generate" under the "Generated access token" heading. Copy the generated token token. Note that it is longer than the display, so exercise care in copying _all_ of it. Save the token in either `~/.config/git/git-remote-dropbox.json` or `~/.git-remote-dropbox.json`. The file looks like:
-   ```json
-   {
-      "default": "xxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-   }
-   ```
-
-### B. Local software installation
+### Install git-remote-dropbox
 
 1. Prerequisites:
    1. `python` and matching `pip`
    2. `git`
 2. Install this package with `pip install git-remote-dropbox`. Use `which git-remote-dropbox` to make sure it's available via `$PATH`. If not, edit `$PATH` appropriately.
 
-### __Note about access tokens__
+### Log in to Dropbox
 
-1. The access token you have will now enable access to your entire Dropbox, from any machine. It is valid until you either delete the app or regenerate the access token. Keep this token a secret. In particular, you should **NOT** share this for making a shared repo (see [Sharing](#sharing) below for the right way to do that).
-
-2. If you have multiple Dropbox accounts, this token will access only the one that was logged in when you created the Dropbox app. You can specify alternate ones in the config file and reference them via the pathname (see [Multiple Accounts](#multiple-accounts) below).
+Run `git dropbox login` and follow the instructions to authenticate with OAuth
+and log in to your Dropbox account.
 
 ## Sharing
 
-The above gives you a way to create a Git repository on Dropbox and use it from multiple machines that you own (that have the access token). In other words, it's a convenient way to share a remote with your laptop and your desktop.
+The above gives you a way to create a Git repository on Dropbox and use it from multiple machines that you own. In other words, it's a convenient way to share a remote with your laptop and your desktop.
 
-If you want to share with other people, you should explicitly share (e.g. via the Dropbox website) the root folder of the repo with your collaborators. Then they should follow steps (A) and (B) above to generate their own access token to use `git-remote-dropbox`. **Collaborators do not need _your_ access token.**
+If you want to share with other people, you should explicitly share (e.g. via the Dropbox website) the root folder of the repo with your collaborators. Then they should also install git-remote-dropbox and log in *with their own account*.
 
 ## Multiple Accounts
 
-`git-remote-dropbox` supports using multiple Dropbox accounts. You can create
-OAuth tokens for different accounts and add them all to the config file, using
-a user-defined username as the key:
+git-remote-dropbox supports using multiple Dropbox accounts. You can have named
+accounts with `git dropbox login <username>`. **These usernames are unrelated
+to your Dropbox login; you can choose whatever names you want to organize your
+accounts, e.g. "work".**
 
-```json
-{
-    "alice": "xxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxx",
-    "ben": "xxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxx",
-    "charlie": "xxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxx"
-}
-```
-
-You can tell `git-remote-dropbox` to use the token corresponding to `username` by
-specifying a URL like `dropbox://username@/path/to/repo`.
-
-You can also specify the token inline by using a URL like
-`dropbox://:token@/path/to/repo`.
+You can tell git-remote-dropbox to use a particular account by setting the git
+remote URL appropriately, specifying a username like:
+`dropbox://username@/path/to/repo`.
 
 ## Repository Manager
 
-In addition to the git remote helper, `git-remote-dropbox` comes with an
-additional tool to manage repositories on Dropbox. This tool can be invoked as
-`git dropbox`. You can also create an alias for it with the following:
+In addition to the git remote helper, git-remote-dropbox comes with an
+additional tool to manage your logins and repositories on Dropbox. This tool
+can be invoked as `git dropbox`.
 
-Currently the tool supports a single subcommand, `git dropbox set-head <remote>
-<branch>`, that can be used to set the default branch on the remote.
+The tool supports the following commands:
+
+- `git dropbox login [username]`: log in, either with the default account (no
+  need to specify a username in remote), or with an alias (for multi-account
+  support)
+- `git dropbox logout [username]`: log out
+- `git dropbox show-logins`: list logged-in accounts
+- `git dropbox set-head <remote> <branch>`: set default branch on the remote
+- `git dropbox version`: show version
 
 ## Notes
 
@@ -189,5 +161,5 @@ information on what you can do about that.
 
 ## License
 
-Copyright (c) 2015-2021 Anish Athalye. Released under the MIT License. See
+Copyright (c) 2015-2022 Anish Athalye. Released under the MIT License. See
 [LICENSE.md](LICENSE.md) for details.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ concurrent operations, even when using a shared folder.
    1. `python` and matching `pip`
    2. `git`
 2. Install this package with `pip install git-remote-dropbox`. Use `which git-remote-dropbox` to make sure it's available via `$PATH`. If not, edit `$PATH` appropriately.
-3. Add an alias for the manager tool with `git config --global alias.dropbox '!git-dropbox-manage'`.
 
 ### __Note about access tokens__
 
@@ -105,13 +104,7 @@ You can also specify the token inline by using a URL like
 
 In addition to the git remote helper, `git-remote-dropbox` comes with an
 additional tool to manage repositories on Dropbox. This tool can be invoked as
-`git-dropbox-manage`. You can also create an alias for it with the following:
-
-```bash
-git config --global alias.dropbox '!git-dropbox-manage'
-```
-
-With this configuration, the tool can be invoked as `git dropbox`.
+`git dropbox`. You can also create an alias for it with the following:
 
 Currently the tool supports a single subcommand, `git dropbox set-head <remote>
 <branch>`, that can be used to set the default branch on the remote.
@@ -136,7 +129,7 @@ Currently the tool supports a single subcommand, `git dropbox set-head <remote>
 - If the remote HEAD (default branch on the remote) is not set, after cloning a
   repository from Dropbox, Git will not automatically check out a branch. To
   check out a branch, run `git checkout <branch>`. To set the default branch on
-  the remote, use the [git-dropbox-manage](#repository-manager) command.
+  the remote, use the [`git dropbox`](#repository-manager) command.
 
 ## FAQ
 

--- a/git_remote_dropbox/__init__.py
+++ b/git_remote_dropbox/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 Anish Athalye (me@anishathalye.com)
+# Copyright (c) 2015-2022 Anish Athalye (me@anishathalye.com)
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/git_remote_dropbox/cli/common.py
+++ b/git_remote_dropbox/cli/common.py
@@ -3,44 +3,21 @@ from git_remote_dropbox.util import (
     stderr,
 )
 from git_remote_dropbox.helper import Helper
+from git_remote_dropbox.constants import APP_KEY
+
+import dropbox  # type: ignore
 
 import os
-
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
+from typing import Callable, NoReturn
+from urllib.parse import urlparse
 
 
-def error(msg):
+def error(msg: str) -> NoReturn:
     stderr("error: %s\n" % msg)
     exit(1)
 
 
-def get_helper(url):
-    """
-    Return a Helper configured to point at the given URL.
-
-    URLs are one of:
-        dropbox:///path/to/repo
-        dropbox://username@/path/to/repo
-        dropbox://:token@/path/to/repo
-    """
-    url = urlparse(url)
-    if url.scheme != "dropbox":
-        error('URL must start with the "dropbox://" scheme')
-    if url.netloc:
-        if not url.username and not url.password:
-            # user probably put in something like "dropbox://path/to/repo"
-            # missing the third "/"
-            error('URL with no username or token must start with "dropbox:///"')
-        if url.username and url.password:
-            # user supplied both username and token
-            error("URL must not specify both username and token")
-    path = url.path.lower()  # dropbox is case insensitive, so we must canonicalize
-    if path.endswith("/"):
-        error("URL path must not have trailing slash")
-
+def get_config() -> Config:
     config_files = [
         os.path.join(
             os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
@@ -49,27 +26,79 @@ def get_helper(url):
         ),
         os.path.expanduser("~/.git-remote-dropbox.json"),
     ]
-    config = None
-    for config_file in config_files:
-        try:
-            config = Config(config_file)
-        except ValueError:
-            error("malformed config file: %s" % config_file)
-        except IOError:
-            continue
-        else:
-            break
-    if not config and not url.password:
-        error("missing config file: %s" % config_files[0])
-    try:
-        if url.password:
-            token = url.password
-        elif not url.username:
-            token = config["default"]
-        else:
-            token = config[url.username]
-    except KeyError:
-        token_name = url.username or "default"
-        error('config file missing token for key "%s"' % token_name)
+    for path in config_files:
+        if os.path.exists(path):
+            return Config(path)
+    path = config_files[0]
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    return Config(path, create=True)
 
-    return Helper(token, path)
+
+def make_connector(token_type: str, token: str) -> Callable[[], dropbox.Dropbox]:
+    if token_type == "long-lived":
+        return lambda: dropbox.Dropbox(token)
+    elif token_type == "refresh":
+        return lambda: dropbox.Dropbox(oauth2_refresh_token=token, app_key=APP_KEY)
+    else:
+        raise ValueError("cannot handle token type: %s" % token_type)
+
+
+def check_connection(dbx: dropbox.Dropbox) -> None:
+    dbx.users_get_current_account()
+
+
+def get_helper(url: str) -> Helper:
+    """
+    Return a Helper configured to point at the given URL.
+
+    URLs must be formatted as:
+        dropbox:///path/to/repo
+        dropbox://username@/path/to/repo
+        dropbox://:token@/path/to/repo
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "dropbox":
+        error('URL must start with the "dropbox://" scheme')
+    if parsed.netloc:
+        if not parsed.username and not parsed.password:
+            # user probably put in something like "dropbox://path/to/repo"
+            # missing the third "/"
+            error('URL with no username or token must start with "dropbox:///"')
+        if parsed.username and parsed.password:
+            # user supplied both username and token
+            error("URL must not specify both username and token")
+    path = parsed.path.lower()  # dropbox is case insensitive, so we must canonicalize
+    if path.endswith("/"):
+        error("URL path must not have trailing slash")
+
+    config = get_config()
+    if parsed.password:
+        token_type = "long-lived"
+        token = parsed.password
+    elif parsed.username:
+        token_rep = config["tokens"]["named"].get(parsed.username)
+        if not token_rep:
+            error("you must log in first with 'git dropbox login %s'" % parsed.username)
+        token_type, token = token_rep
+    else:
+        token_rep = config["tokens"]["default"]
+        if not token_rep:
+            error("you must log in first with 'git dropbox login'")
+        token_type, token = token_rep
+    connector = make_connector(token_type, token)
+    try:
+        check_connection(connector())
+    except dropbox.exceptions.DropboxException:
+        if parsed.password:
+            error(
+                "invalid inline legacy access token, try switching to short-lived access tokens with 'git dropbox login'"
+            )
+        elif parsed.username:
+            error(
+                "invalid access token, try logging in again with 'git dropbox login %s'"
+                % parsed.username
+            )
+        else:
+            error("invalid access token, try logging in again with 'git dropbox login'")
+
+    return Helper(connector, path)

--- a/git_remote_dropbox/cli/helper.py
+++ b/git_remote_dropbox/cli/helper.py
@@ -10,7 +10,7 @@ from git_remote_dropbox.cli.common import (
 import sys
 
 
-def main():
+def main() -> None:
     """
     Main entry point for git-remote-dropbox Git remote helper.
     """

--- a/git_remote_dropbox/cli/helper.py
+++ b/git_remote_dropbox/cli/helper.py
@@ -28,4 +28,4 @@ def main() -> None:
             error("unexpected exception (run with -v for details)")
     except KeyboardInterrupt:
         # exit silently with an error code
-        exit(1)
+        sys.exit(1)

--- a/git_remote_dropbox/cli/manage.py
+++ b/git_remote_dropbox/cli/manage.py
@@ -11,7 +11,7 @@ import subprocess
 
 def main():
     """
-    Main entry point for git-dropbox-manage program.
+    Main entry point for git-dropbox program.
     """
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()

--- a/git_remote_dropbox/constants.py
+++ b/git_remote_dropbox/constants.py
@@ -1,8 +1,9 @@
 import os
+from typing import TextIO
 
 
-CONFIG_FILE = "~/.git-remote-dropbox.json"
-DEVNULL = open(os.devnull, "w")
-PROCESSES = 20
-MAX_RETRIES = 3
-CHUNK_SIZE = 50 * 1024 * 1024  # 50 megabytes
+APP_KEY: str = "h7d8z1irmz0r7lp"
+DEVNULL: TextIO = open(os.devnull, "w")
+PROCESSES: int = 20
+MAX_RETRIES: int = 3
+CHUNK_SIZE: int = 50 * 1024 * 1024  # 50 megabytes

--- a/git_remote_dropbox/git.py
+++ b/git_remote_dropbox/git.py
@@ -2,7 +2,7 @@ from git_remote_dropbox.constants import DEVNULL
 
 import subprocess
 import zlib
-from typing import overload, Optional, Union, List
+from typing import Optional, List
 
 
 EMPTY_TREE_HASH: str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
@@ -118,13 +118,13 @@ def decode_object(data: bytes) -> str:
 
 
 def write_object(kind: str, contents: bytes) -> str:
-    p = subprocess.Popen(
+    with subprocess.Popen(
         ["git", "hash-object", "-w", "--stdin", "-t", kind],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=DEVNULL,
-    )
-    sha = p.communicate(contents)[0].decode("utf8").strip()
+    ) as p:
+        sha = p.communicate(contents)[0].decode("utf8").strip()
     return sha
 
 
@@ -151,7 +151,7 @@ def referenced_objects(sha: str) -> List[str]:
     data = object_data(sha).decode("utf8").strip()
     if kind == "tag":
         # tag objects reference a single object
-        obj = data.split("\n")[0].split()[1]
+        obj = data.split("\n", maxsplit=1)[0].split()[1]
         return [obj]
     elif kind == "commit":
         # commit objects reference a tree and zero or more parents

--- a/git_remote_dropbox/git.py
+++ b/git_remote_dropbox/git.py
@@ -128,7 +128,7 @@ def write_object(kind: str, contents: bytes) -> str:
     return sha
 
 
-def list_objects(ref: str, exclude: List[str]):
+def list_objects(ref: str, exclude: List[str]) -> List[str]:
     """
     Return the objects reachable from ref excluding the objects reachable from
     exclude.

--- a/git_remote_dropbox/git.py
+++ b/git_remote_dropbox/git.py
@@ -2,25 +2,29 @@ from git_remote_dropbox.constants import DEVNULL
 
 import subprocess
 import zlib
+from typing import overload, Optional, Union, List
 
 
-EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+EMPTY_TREE_HASH: str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 
-def command_output(*args, **kwargs):
+def command_output_raw(*args: str) -> bytes:
     """
-    Return the result of running a git command.
+    Return the raw result of running a git command.
     """
     args = ("git",) + args
     output = subprocess.check_output(args, stderr=DEVNULL)
-    if kwargs.get("decode", True):
-        output = output.decode("utf8")
-    if kwargs.get("strip", True):
-        output = output.strip()
     return output
 
 
-def command_ok(*args):
+def command_output(*args: str) -> str:
+    """
+    Return the raw result of running a git command.
+    """
+    return command_output_raw(*args).decode("utf8").strip()
+
+
+def command_ok(*args: str) -> bool:
     """
     Return whether a git command runs successfully.
     """
@@ -28,7 +32,7 @@ def command_ok(*args):
     return subprocess.call(args, stdout=DEVNULL, stderr=DEVNULL) == 0
 
 
-def is_ancestor(ancestor, ref):
+def is_ancestor(ancestor: str, ref: str) -> bool:
     """
     Return whether ancestor is an ancestor of ref.
 
@@ -37,14 +41,14 @@ def is_ancestor(ancestor, ref):
     return command_ok("merge-base", "--is-ancestor", ancestor, ref)
 
 
-def object_exists(sha):
+def object_exists(sha: str) -> bool:
     """
     Return whether the object exists in the repository.
     """
     return command_ok("cat-file", "-e", sha)
 
 
-def history_exists(sha):
+def history_exists(sha: str) -> bool:
     """
     Return whether the object, along with its history, exists in the
     repository.
@@ -52,40 +56,40 @@ def history_exists(sha):
     return command_ok("rev-list", "--objects", sha)
 
 
-def ref_value(ref):
+def ref_value(ref: str) -> str:
     """
     Return the hash of the ref.
     """
     return command_output("rev-parse", ref)
 
 
-def symbolic_ref_value(name):
+def symbolic_ref_value(name: str) -> str:
     """
     Return the branch head to which the symbolic ref refers.
     """
     return command_output("symbolic-ref", name)
 
 
-def object_kind(sha):
+def object_kind(sha: str) -> str:
     """
     Return the type of the object.
     """
     return command_output("cat-file", "-t", sha)
 
 
-def object_data(sha, kind=None):
+def object_data(sha: str, kind: Optional[str] = None) -> bytes:
     """
     Return the contents of the object.
 
     If kind is None, return a pretty-printed representation of the object.
     """
     if kind is not None:
-        return command_output("cat-file", kind, sha, decode=False, strip=False)
+        return command_output_raw("cat-file", kind, sha)
     else:
-        return command_output("cat-file", "-p", sha, decode=False, strip=False)
+        return command_output_raw("cat-file", "-p", sha)
 
 
-def encode_object(sha):
+def encode_object(sha: str) -> bytes:
     """
     Return the encoded contents of the object.
 
@@ -101,7 +105,7 @@ def encode_object(sha):
     return compressed
 
 
-def decode_object(data):
+def decode_object(data: bytes) -> str:
     """
     Decode the object, write it, and return the computed hash.
 
@@ -113,7 +117,7 @@ def decode_object(data):
     return write_object(kind.decode("utf8"), contents)
 
 
-def write_object(kind, contents):
+def write_object(kind: str, contents: bytes) -> str:
     p = subprocess.Popen(
         ["git", "hash-object", "-w", "--stdin", "-t", kind],
         stdin=subprocess.PIPE,
@@ -124,7 +128,7 @@ def write_object(kind, contents):
     return sha
 
 
-def list_objects(ref, exclude):
+def list_objects(ref: str, exclude: List[str]):
     """
     Return the objects reachable from ref excluding the objects reachable from
     exclude.
@@ -136,7 +140,7 @@ def list_objects(ref, exclude):
     return [i.split()[0] for i in objects.split("\n")]
 
 
-def referenced_objects(sha):
+def referenced_objects(sha: str) -> List[str]:
     """
     Return the objects directly referenced by the object.
     """
@@ -173,7 +177,7 @@ def referenced_objects(sha):
         raise Exception("unexpected git object type: %s" % kind)
 
 
-def get_remote_url(name):
+def get_remote_url(name: str) -> str:
     """
     Return the URL of the given remote.
     """

--- a/git_remote_dropbox/helper.py
+++ b/git_remote_dropbox/helper.py
@@ -41,7 +41,7 @@ class Helper:
 
     def __init__(
         self, connector: Callable[[], dropbox.Dropbox], path: str, processes: int = PROCESSES
-    ):
+    ) -> None:
         self._connector = connector
         self._per_thread = threading.local()
         self._path = path
@@ -511,7 +511,7 @@ class Helper:
             refs.append((sha, name))
         return refs
 
-    def write_symbolic_ref(self, path: str, ref: str, rev: Optional[str] = None):
+    def write_symbolic_ref(self, path: str, ref: str, rev: Optional[str] = None) -> bool:
         """
         Write the given symbolic ref to the remote.
 

--- a/git_remote_dropbox/util.py
+++ b/git_remote_dropbox/util.py
@@ -135,17 +135,17 @@ class Config:
             self.save()
         with open(filename) as f:
             self._settings = json.load(f)
-            version = self._settings.get("version")
-            # try to migrate
-            if version is None:
-                # v1 style config, before we had versions
-                self._settings = _migrate_config_v1_to_v2(self._settings)
-                self.save()
-            elif version != self.VERSION:
-                raise ValueError(
-                    'expected config version %d, got %s; delete the config file "%s" to re-initialize'
-                    % (self.VERSION, version, filename)
-                )
+        version = self._settings.get("version")
+        # try to migrate
+        if version is None:
+            # v1 style config, before we had versions
+            self._settings = _migrate_config_v1_to_v2(self._settings)
+            self.save()
+        elif version != self.VERSION:
+            raise ValueError(
+                'expected config version %d, got %s; delete the config file "%s" to re-initialize'
+                % (self.VERSION, version, filename)
+            )
 
     def get(self, key: str, value: Any = None) -> Any:
         return self._settings.get(key, value)
@@ -197,6 +197,7 @@ def atomic_write(contents: bytes, path: str) -> None:
         temp_file.write(contents)
         temp_file.flush()
         os.fsync(temp_file.fileno())
+        temp_file.close()  # necessary on Windows because we can't move an open file
         os.replace(temp_file.name, path)
     finally:
         try:

--- a/git_remote_dropbox/util.py
+++ b/git_remote_dropbox/util.py
@@ -1,9 +1,11 @@
 import json
 import os
 import sys
+import tempfile
+from typing import Optional, Any, Dict, List
 
 
-def stdout(line):
+def stdout(line: str) -> None:
     """
     Write line to standard output.
     """
@@ -11,7 +13,7 @@ def stdout(line):
     sys.stdout.flush()
 
 
-def stderr(line):
+def stderr(line: str) -> None:
     """
     Write line to standard error.
     """
@@ -19,14 +21,14 @@ def stderr(line):
     sys.stderr.flush()
 
 
-def readline():
+def readline() -> str:
     """
     Read a line from standard input.
     """
     return sys.stdin.readline().strip()  # remove trailing newline
 
 
-def stdout_to_binary():
+def stdout_to_binary() -> None:
     """
     Ensure that stdout is in binary mode on windows
     """
@@ -36,7 +38,7 @@ def stdout_to_binary():
         msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
 
 
-class Level(object):
+class Level:
     """
     A class for severity levels.
     """
@@ -46,7 +48,7 @@ class Level(object):
     DEBUG = 2
 
 
-class Poison(object):
+class Poison:
     """
     A poison pill.
 
@@ -54,11 +56,11 @@ class Poison(object):
     termination requests to processes.
     """
 
-    def __init__(self, message=None):
+    def __init__(self, message: Optional[str] = None) -> None:
         self.message = message
 
 
-class Binder(object):
+class Binder:
     """
     A class to bind a method to an object.
 
@@ -81,7 +83,7 @@ class Binder(object):
     In the above example, it is possible to pickle the `b` object.
     """
 
-    def __init__(self, obj, func_name, *args):
+    def __init__(self, obj: Any, func_name: str, *args: Any) -> None:
         """
         Initialize a Binder with an object and a function by its name.
 
@@ -91,7 +93,7 @@ class Binder(object):
         self._func_name = func_name
         self._args = args
 
-    def __call__(self, *args):
+    def __call__(self, *args: Any) -> Any:
         """
         Call the function bound to the object, passing args if given.
         """
@@ -104,19 +106,100 @@ class Binder(object):
         return method(self._obj, *args)
 
 
-class Config(object):
+class Config:
     """
     A class to manage configuration data.
     """
 
-    def __init__(self, filename):
+    VERSION = 2
+    INITIAL_CONFIG: Dict[str, Any] = {
+        "version": VERSION,
+        "tokens": {
+            "default": None,
+            "named": {},
+        },
+    }
+    """
+    tokens are stored as descriptors of the form
+        [tag, token]
+    where tag is one of ['long-lived', 'refresh']
+
+    "default" stores the default account, while explicitly named usernames are
+    stored in "named"
+    """
+
+    def __init__(self, filename: str, create: bool = False) -> None:
+        self._filename = filename
+        if create:
+            self._settings = self.INITIAL_CONFIG
+            self.save()
         with open(filename) as f:
             self._settings = json.load(f)
+            version = self._settings.get("version")
+            # try to migrate
+            if version is None:
+                # v1 style config, before we had versions
+                self._settings = _migrate_config_v1_to_v2(self._settings)
+                self.save()
+            elif version != self.VERSION:
+                raise ValueError(
+                    'expected config version %d, got %s; delete the config file "%s" to re-initialize'
+                    % (self.VERSION, version, filename)
+                )
 
-    def __getitem__(self, key):
+    def get(self, key: str, value: Any = None) -> Any:
+        return self._settings.get(key, value)
+
+    def __getitem__(self, key: str) -> Any:
         """
         Return the setting corresponding to key.
 
         Raises KeyError if the config file is missing the key.
         """
         return self._settings[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._settings[key] = value
+
+    def save(self) -> None:
+        contents = json.dumps(self._settings, indent=2).encode("utf8")
+        atomic_write(contents, self._filename)
+
+
+def _migrate_config_v1_to_v2(obj: Dict[str, str]) -> Dict[str, Any]:
+    """
+    Migrate a git-remote-dropbox v1 configuration type to a v2-style configuration.
+
+    The v1 configuration mapped strings (usernames) to long-term tokens, and
+    used the string "default" to represent the default account.
+    """
+    named: Dict[str, List[str]] = {}
+    default_token = None
+    for username, token in obj.items():
+        token_rep = ["long-lived", token]
+        if username == "default":
+            default_token = token_rep
+        else:
+            named[username] = token_rep
+    return {
+        "version": 2,
+        "tokens": {
+            "default": default_token,
+            "named": named,
+        },
+    }
+
+
+def atomic_write(contents: bytes, path: str) -> None:
+    # same directory as path to avoid being on a different filesystem
+    try:
+        temp_file = tempfile.NamedTemporaryFile(dir=os.path.dirname(path), delete=False)
+        temp_file.write(contents)
+        temp_file.flush()
+        os.fsync(temp_file.fileno())
+        os.replace(temp_file.name, path)
+    finally:
+        try:
+            os.unlink(temp_file.name)
+        except:
+            pass

--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,12 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Version Control",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     keywords="git dropbox",
     packages=find_packages(),
@@ -57,8 +55,8 @@ setup(
         "console_scripts": [
             "git-remote-dropbox=git_remote_dropbox.cli.helper:main",
             "git-dropbox=git_remote_dropbox.cli.manage:main",
-            # Users might have a `git dropbox` alias set up for `git-dropbox-manage`.
-            # Don't break their config.
+            # Users might have a `git dropbox` alias set up for `git-dropbox-manage`,
+            # according to the old instructions. Don't break their config.
             "git-dropbox-manage=git_remote_dropbox.cli.manage:main",
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,9 @@ setup(
     entry_points={
         "console_scripts": [
             "git-remote-dropbox=git_remote_dropbox.cli.helper:main",
+            "git-dropbox=git_remote_dropbox.cli.manage:main",
+            # Users might have a `git dropbox` alias set up for `git-dropbox-manage`.
+            # Don't break their config.
             "git-dropbox-manage=git_remote_dropbox.cli.manage:main",
         ],
     },

--- a/test/README.md
+++ b/test/README.md
@@ -13,7 +13,7 @@ with the real Dropbox API during the test.
 
 ```bash
 cd /git-remote-dropbox
-pip install -e .
+pip3 install -e .
 cd test
 export DROPBOX_TOKEN='...'
 ./test.sh

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure(2) do |config|
 
-  config.vm.box = 'ubuntu/xenial64'
+  config.vm.box = 'ubuntu/bionic64'
 
   # synced folder
   config.vm.synced_folder '..', '/git-remote-dropbox'
@@ -11,7 +11,12 @@ Vagrant.configure(2) do |config|
   # install packages
   config.vm.provision 'shell', inline: <<-EOS
     apt-get -y update
-    apt-get install -y git python-pip
+    apt-get install -y git python3-pip
+  EOS
+
+  # alias python -> python3
+  config.vm.provision 'shell', inline: <<-EOS
+    sudo ln -s /usr/bin/python3 /usr/bin/python
   EOS
 
   # configure PATH

--- a/test/test.sh
+++ b/test/test.sh
@@ -76,7 +76,7 @@ fi
 ok
 
 section 'set default branch'
-test_expect_success git-dropbox-manage set-head origin develop
+test_expect_success git-dropbox set-head origin develop
 ok
 
 section 'default branch protected'

--- a/test/test.sh
+++ b/test/test.sh
@@ -26,7 +26,7 @@ test_expect_success git push -u origin master
 ok
 
 section 'clone'
-cat >$HOME/.git-remote-dropbox.json <<EOF
+cat >$HOME/.config/git/git-remote-dropbox.json <<EOF
 {
     "default": "${DROPBOX_TOKEN}"
 }


### PR DESCRIPTION
Fixes #103

See [new documentation](https://github.com/anishathalye/git-remote-dropbox/tree/pkce#git-remote-dropbox-).

Installation instructions:

1. Clone the repository and check out the `pkce` branch: `git clone -b pkce https://github.com/anishathalye/git-remote-dropbox`
2. Change into the directory: `cd git-remote-dropbox`
3. Install git-remote-dropbox from the local directory: `pip install .`

**I'd greatly appreciate any feedback on the documentation or with the user experience (or the code, if anyone feels like reading/reviewing it)!**

---

Migrate to using PKCE and refresh tokens

Dropbox deprecated long-lived tokens some time ago and now no longer issues new long-lived tokens [1]. This patch switches git-remote-dropbox to using short-lived tokens using the PKCE flow [2], which also makes the app more user-friendly by not requiring users to manually create a Dropbox app, set up its permissions, and get an access token.

This version of git-remote-dropbox is fully backwards-compatible with the previous version and will automatically migrate configuration files to the new format. It'll continue using long-lived tokens as long as they work, so it won't interrupt users' workflows, but users can switch to the new short-lived tokens / refresh tokens any time.

This patch also adds static typing, and it drops support for Python 2 and Python < 3.6.

This patch does not update the tests: they still use long-lived tokens, which still work as of now (Dropbox just doesn't issue _new_ long-lived tokens anymore, but existing tokens do work).

[1]: https://dropbox.tech/developers/migrating-app-permissions-and-access-tokens
[2]: https://dropbox.tech/developers/pkce--what-and-why-
